### PR TITLE
feat: add langgraph llm agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # PayrollResearchAgent
+
+This repository contains an example LLM-based agent built with [LangGraph](https://github.com/langchain-ai/langgraph).
+The agent demonstrates a simple workflow that sends a user's question to an LLM and returns the model's answer.
+
+## Running the agent
+
+Install the dependencies:
+
+```bash
+pip install langgraph langchain-core langchain-openai langchain-community
+```
+
+Execute the script:
+
+```bash
+python agent.py
+```
+
+By default the script uses a deterministic fake LLM so that it can run offline.
+If an `OPENAI_API_KEY` environment variable is set, the agent will instead use OpenAI's models via `langchain-openai`.

--- a/agent.py
+++ b/agent.py
@@ -1,0 +1,60 @@
+"""Simple LLM-based agent built with LangGraph.
+
+This script demonstrates how to construct a minimal LangGraph workflow
+that routes a user's question through an LLM. If an OpenAI API key is
+available, the agent will call an OpenAI model; otherwise it falls back
+to a deterministic fake LLM so the example can run offline.
+"""
+from __future__ import annotations
+
+from typing import Dict
+
+from langgraph.graph import START, END, StateGraph
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.language_models.fake import FakeListLLM
+
+try:
+    from langchain_openai import ChatOpenAI
+except Exception:  # pragma: no cover - optional dependency
+    ChatOpenAI = None  # type: ignore
+
+
+def get_model():
+    """Return an LLM instance.
+
+    Uses ChatOpenAI if available, otherwise falls back to FakeListLLM so the
+    script can run without external credentials.
+    """
+    if ChatOpenAI is not None:
+        try:
+            return ChatOpenAI()
+        except Exception:
+            pass
+    return FakeListLLM(responses=["Hello from a fake LLM!"], n=1)
+
+
+def build_agent():
+    """Compile and return a LangGraph app that answers a question."""
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", "You are a helpful assistant."),
+        ("human", "{question}"),
+    ])
+    model = get_model()
+    chain = prompt | model | StrOutputParser()
+
+    def call_model(state: Dict[str, str]) -> Dict[str, str]:
+        answer = chain.invoke({"question": state["question"]})
+        return {"answer": answer}
+
+    workflow = StateGraph(dict)
+    workflow.add_node("model", call_model)
+    workflow.add_edge(START, "model")
+    workflow.add_edge("model", END)
+    return workflow.compile()
+
+
+if __name__ == "__main__":
+    app = build_agent()
+    result = app.invoke({"question": "What is LangGraph?"})
+    print(result["answer"])


### PR DESCRIPTION
## Summary
- add example LangGraph-based agent that answers questions using an LLM
- document how to run the agent and install dependencies

## Testing
- `python agent.py`
- `python -m py_compile agent.py`


------
https://chatgpt.com/codex/tasks/task_e_688ec945bfb483259b1b1e75b6b6e6bb